### PR TITLE
Minor bugfix to allow quitting from config mode

### DIFF
--- a/libboardgame_gtp/CmdLine.cpp
+++ b/libboardgame_gtp/CmdLine.cpp
@@ -66,7 +66,7 @@ string_view CmdLine::get_trimmed_line_after_elem(unsigned i) const
 {
     assert(i < m_elem.size());
     auto& e = m_elem[i];
-    auto begin = e.end();
+    auto begin = &*e.end();
     auto end = &*m_line.end();
     if (begin < end && *begin == '"')
         ++begin;

--- a/libboardgame_gtp/GtpEngine.cpp
+++ b/libboardgame_gtp/GtpEngine.cpp
@@ -115,7 +115,7 @@ bool GtpEngine::exec(istream& in, bool throw_on_fail, ostream* log)
     Response response;
     string buffer;
     CmdLine cmd;
-    while (getline(in, line))
+    while (!m_quit && getline(in, line))
     {
         if (! is_cmd_line(line))
             continue;
@@ -135,7 +135,6 @@ bool GtpEngine::exec(istream& in, bool throw_on_fail, ostream* log)
 
 void GtpEngine::exec_main_loop(istream& in, ostream& out)
 {
-    m_quit = false;
     CmdLine cmd;
     Response response;
     string buffer;

--- a/libboardgame_gtp/GtpEngine.h
+++ b/libboardgame_gtp/GtpEngine.h
@@ -119,7 +119,7 @@ protected:
 
 private:
     /** Flag to quit main loop. */
-    bool m_quit;
+    bool m_quit = false;
 
     map<string, Handler> m_handlers;
 


### PR DESCRIPTION
I noticed that when running Pentobi GPT in config mode (by passing in a text file commands) like this:

`pentobi-gtp.exe -g classic -r 42 --nobook --noresign --threads 1 -c commands.gpt`

where the commands.gpt looks like this:

`loadsgf board.blksgf
g
showboard
quit`

the process wouldn't quit automatically after processing these commands. This is a minor PR to address this issue.
