### PR TITLE
Remove needless check for metainfo.its

### DIFF
--- a/pentobi/unix/CMakeLists.txt
+++ b/pentobi/unix/CMakeLists.txt
@@ -1,19 +1,3 @@
-# The AppData ITS file (named metainfo.its or appdata.its) is usually installed
-# in the gettext folder but provided but the appdata package. We want to check
-# its existence already at configuration time.
-get_filename_component(GETTEXT_BIN_DIR ${GETTEXT_MSGFMT_EXECUTABLE} DIRECTORY)
-get_filename_component(GETTEXT_INSTALL_DIR ${GETTEXT_BIN_DIR} DIRECTORY)
-find_file(METAINFO_ITS NAMES metainfo.its appdata.its
-    HINTS ${GETTEXT_INSTALL_DIR}/share/gettext/its
-    )
-if(NOT METAINFO_ITS)
-    message(FATAL_ERROR
-        "metainfo.its not found. Install appstream and/or use"
-        " -DMETAINFO_ITS=<file> to define the location of the metainfo.its"
-        " or appdata.its file."
-        )
-endif()
-
 # Binary gettext files
 
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/po/LINGUAS" linguas)


### PR DESCRIPTION
It's not needed as detected ${METAINFO_ITS} is not used anywhere, and it breaks the build on e.g. FreeBSD where the file resides in e.g. `/usr/local/share/gettext-0.21/its` which is neither detected correctly nor can be specified manually due to unknown gettext version on the target system.