### PR TITLE
Consistent file headers for QML translation files

### DIFF
--- a/pentobi/qml/i18n/qml_en.ts
+++ b/pentobi/qml/i18n/qml_en.ts
@@ -1,6 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS>
-<TS version="2.1" language="en_US">
+<?xml version="1.0" ?><!DOCTYPE TS><TS language="en_US" version="2.1">
 <context>
     <name>AboutDialog</name>
     <message>


### PR DESCRIPTION
Somehow the source file is empty in https://hosted.weblate.org/projects/pentobi/game/
I think this will do.