### PR TITLE
Fix Windows build

### DIFF
--- a/pentobi/docbook/CMakeLists.txt
+++ b/pentobi/docbook/CMakeLists.txt
@@ -52,12 +52,8 @@ add_custom_command(OUTPUT "help/C/index.html"
     COMMAND "${XSLTPROC}" --nonet --novalid --path "${DOCBOOKXSL_DIR}/html"
     -o "help/C/" "${CMAKE_CURRENT_SOURCE_DIR}/custom.xsl"
     "${CMAKE_CURRENT_SOURCE_DIR}/index.docbook"
-    COMMAND ${CMAKE_COMMAND} -E copy
-    "${CMAKE_CURRENT_SOURCE_DIR}/figures/*.png" "help/C/"
-    COMMAND ${CMAKE_COMMAND} -E copy
-    "${CMAKE_CURRENT_SOURCE_DIR}/figures/*.jpg" "help/C/"
-    COMMAND ${CMAKE_COMMAND} -E copy
-    "${CMAKE_CURRENT_SOURCE_DIR}/figures/stylesheet.css" "help/C/"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+    "${CMAKE_CURRENT_SOURCE_DIR}/figures" "help/C/"
     DEPENDS ${DOCBOOK_SRC}
     )
 

--- a/pentobi/qml/Main.js
+++ b/pentobi/qml/Main.js
@@ -359,7 +359,8 @@ function help() {
     else {
         var url
         if (helpDir)
-            url = "file://" + helpDir + "/" + lang + "/index.html"
+            url = "file://" + (Qt.platform.os == "windows" ? "/" : "")
+                  + helpDir + "/" + lang + "/index.html"
         else
             url = "qrc:///qml/help/" + lang + "/index.html"
         if (! Qt.openUrlExternally(url))


### PR DESCRIPTION
- Changed documentation file copy command because original command doesn't work with wildcards. (See https://cmake.org/cmake/help/latest/manual/cmake.1.html for details.)
- Fixed help file path in Main.cpp and Main.js.