### PR TITLE
Fix opening, saving and exporting files in Windows

### DIFF
--- a/pentobi/qml/Main.js
+++ b/pentobi/qml/Main.js
@@ -255,6 +255,8 @@ function genMove() {
 function getFileFromUrl(fileUrl) {
     var file = fileUrl.toString()
     file = file.replace(/^(file:\/{3})/,"/")
+    if (Qt.platform.os == "windows")
+        file = file.replace(/^\/(\w:)/,"$1").replace(/\//g,"\\")
     return decodeURIComponent(file)
 }
 


### PR DESCRIPTION
The function getFileFromUrl for file:/// URL is fixed in Windows, fixing failures in opening, saving and exporting files.
