### PR TITLE
Use native file dialogs in Windows

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,6 +6,11 @@ Main Developer
 
 * Markus Enzenberger <enz@users.sourceforge.net>
 
+Contributors
+------------
+
+* Wing-chung Leung <lwchkg@gmail.com>
+
 Translators
 -----------
 

--- a/pentobi/qml/AsciiArtSaveDialogNative.qml
+++ b/pentobi/qml/AsciiArtSaveDialogNative.qml
@@ -1,0 +1,20 @@
+//-----------------------------------------------------------------------------
+/** @file pentobi/qml/AsciiArtSaveDialog.qml
+    @author Markus Enzenberger
+    @copyright GNU General Public License version 3 or later */
+//-----------------------------------------------------------------------------
+
+import QtQuick.Dialogs
+import "Main.js" as Logic
+
+FileDialog {
+    title: qsTr("Export ASCII Art")
+    defaultSuffix: "txt"
+    nameFilters: [ qsTr("Text files") + " (*.txt)" ]
+    currentFolder: rootWindow.folder
+    fileMode: FileDialog.SaveFile
+    onAccepted: {
+        rootWindow.folder = currentFolder
+        Logic.exportAsciiArt(selectedFile)
+    }
+}

--- a/pentobi/qml/AsciiArtSaveDialogNative.qml
+++ b/pentobi/qml/AsciiArtSaveDialogNative.qml
@@ -1,6 +1,6 @@
 //-----------------------------------------------------------------------------
 /** @file pentobi/qml/AsciiArtSaveDialog.qml
-    @author Markus Enzenberger
+    @author Wing-chung Leung
     @copyright GNU General Public License version 3 or later */
 //-----------------------------------------------------------------------------
 

--- a/pentobi/qml/ExportImageDialog.qml
+++ b/pentobi/qml/ExportImageDialog.qml
@@ -27,8 +27,10 @@ PentobiDialog {
             androidUtils.openImageSaveDialog(name)
         else {
             var dialog = imageSaveDialog.get()
-            dialog.name = name
-            dialog.selectNameFilter(0)
+            if (! rootWindow.useNativeFileDialog) {
+                dialog.name = name
+                dialog.selectNameFilter(0)
+            }
             dialog.open()
         }
     }

--- a/pentobi/qml/ImageSaveDialogNative.qml
+++ b/pentobi/qml/ImageSaveDialogNative.qml
@@ -1,6 +1,6 @@
 //-----------------------------------------------------------------------------
 /** @file pentobi/qml/ImageSaveDialog.qml
-    @author Markus Enzenberger
+    @author Wing-chung Leung
     @copyright GNU General Public License version 3 or later */
 //-----------------------------------------------------------------------------
 

--- a/pentobi/qml/ImageSaveDialogNative.qml
+++ b/pentobi/qml/ImageSaveDialogNative.qml
@@ -1,0 +1,23 @@
+//-----------------------------------------------------------------------------
+/** @file pentobi/qml/ImageSaveDialog.qml
+    @author Markus Enzenberger
+    @copyright GNU General Public License version 3 or later */
+//-----------------------------------------------------------------------------
+
+import QtQuick.Dialogs
+import "Main.js" as Logic
+
+FileDialog {
+    title: qsTr("Save Image")
+    defaultSuffix: "png"
+    nameFilters: [
+        qsTr("PNG image files") + " (*.png)",
+        qsTr("JPEG image files") + " (*.jpg *.jpeg)"
+    ]
+    currentFolder: rootWindow.folder
+    fileMode: FileDialog.SaveFile
+    onAccepted: {
+        rootWindow.folder = currentFolder
+        Logic.exportImage(selectedFile)
+    }
+}

--- a/pentobi/qml/Main.js
+++ b/pentobi/qml/Main.js
@@ -739,7 +739,8 @@ function saveAs() {
         androidUtils.openSaveDialog(file, name)
     } else {
         var dialog = saveDialog.get()
-        dialog.name = gameModel.suggestGameFileName(folder)
+        if (! useNativeFileDialog)
+            dialog.name = gameModel.suggestGameFileName(folder)
         dialog.open()
     }
 }
@@ -834,8 +835,4 @@ function verify(callback) {
         return
     }
     callback()
-}
-
-function useNativeDialog() {
-    return Qt.platform.os == "windows"
 }

--- a/pentobi/qml/Main.js
+++ b/pentobi/qml/Main.js
@@ -540,8 +540,8 @@ function openFileBlocking(file, displayName) {
         gameView.showPieces()
 }
 
-function openFileUrl() {
-    openFile(getFileFromUrl(openDialog.item.fileUrl), "")
+function openFileUrl(fileUrl) {
+    openFile(getFileFromUrl(fileUrl), "")
 }
 
 function openClipboard() {
@@ -834,4 +834,8 @@ function verify(callback) {
         return
     }
     callback()
+}
+
+function useNativeDialog() {
+    return Qt.platform.os == "windows"
 }

--- a/pentobi/qml/Main.qml
+++ b/pentobi/qml/Main.qml
@@ -31,6 +31,10 @@ ApplicationWindow {
 
     property bool isAndroid: Qt.platform.os === "android"
 
+    property bool isWindows: Qt.platform.os === "windows"
+
+    property bool useNativeFileDialog: isWindows
+
     property string themeName: isAndroid ? "dark" : "system"
 
     property QtObject theme: Logic.createTheme(themeName)
@@ -170,13 +174,25 @@ ApplicationWindow {
     DialogLoader { id: gameInfoDialog; url: "GameInfoDialog.qml" }
     DialogLoader { id: initialRatingDialog; url: "InitialRatingDialog.qml" }
     DialogLoader { id: newFolderDialog; url: "NewFolderDialog.qml" }
-    DialogLoader { id: openDialog; url: (Logic.useNativeDialog() ? "OpenDialogNative.qml" : "OpenDialog.qml") }
+    DialogLoader {
+        id: openDialog;
+        url: useNativeFileDialog ? "OpenDialogNative.qml" : "OpenDialog.qml"
+    }
     DialogLoader { id: exportImageDialog; url: "ExportImageDialog.qml" }
-    DialogLoader { id: imageSaveDialog; url: "ImageSaveDialog.qml" }
-    DialogLoader { id: asciiArtSaveDialog; url: "AsciiArtSaveDialog.qml" }
+    DialogLoader {
+        id: imageSaveDialog;
+        url: useNativeFileDialog ? "ImageSaveDialogNative.qml" : "ImageSaveDialog.qml"
+    }
+    DialogLoader {
+        id: asciiArtSaveDialog;
+        url: useNativeFileDialog ? "AsciiArtSaveDialogNative.qml" : "AsciiArtSaveDialog.qml"
+    }
     DialogLoader { id: gotoMoveDialog; url: "GotoMoveDialog.qml" }
     DialogLoader { id: ratingDialog; url: "RatingDialog.qml" }
-    DialogLoader { id: saveDialog; url: "SaveDialog.qml" }
+    DialogLoader {
+        id: saveDialog;
+        url: useNativeFileDialog ? "SaveDialogNative.qml" : "SaveDialog.qml"
+    }
     DialogLoader { id: infoMessage; url: "MessageDialog.qml" }
     DialogLoader { id: questionMessage; url: "QuestionDialog.qml" }
     DialogLoader { id: analyzeDialog; url: "AnalyzeDialog.qml" }

--- a/pentobi/qml/Main.qml
+++ b/pentobi/qml/Main.qml
@@ -170,7 +170,7 @@ ApplicationWindow {
     DialogLoader { id: gameInfoDialog; url: "GameInfoDialog.qml" }
     DialogLoader { id: initialRatingDialog; url: "InitialRatingDialog.qml" }
     DialogLoader { id: newFolderDialog; url: "NewFolderDialog.qml" }
-    DialogLoader { id: openDialog; url: "OpenDialog.qml" }
+    DialogLoader { id: openDialog; url: (Logic.useNativeDialog() ? "OpenDialogNative.qml" : "OpenDialog.qml") }
     DialogLoader { id: exportImageDialog; url: "ExportImageDialog.qml" }
     DialogLoader { id: imageSaveDialog; url: "ImageSaveDialog.qml" }
     DialogLoader { id: asciiArtSaveDialog; url: "AsciiArtSaveDialog.qml" }

--- a/pentobi/qml/MenuExport.qml
+++ b/pentobi/qml/MenuExport.qml
@@ -20,8 +20,10 @@ PentobiMenu {
                 androidUtils.openTextSaveDialog()
             else {
                 var dialog = asciiArtSaveDialog.get()
-                dialog.name = gameModel.suggestFileName(folder, "txt")
-                dialog.selectNameFilter(0)
+                if (! rootWindow.useNativeFileDialog) {
+                    dialog.name = gameModel.suggestFileName(folder, "txt")
+                    dialog.selectNameFilter(0)
+                }
                 dialog.open()
             }
     }

--- a/pentobi/qml/OpenDialogNative.qml
+++ b/pentobi/qml/OpenDialogNative.qml
@@ -1,20 +1,19 @@
 //-----------------------------------------------------------------------------
-/** @file pentobi/qml/OpenDialog.qml
+/** @file pentobi/qml/OpenDialogNative.qml
     @author Markus Enzenberger
     @copyright GNU General Public License version 3 or later */
 //-----------------------------------------------------------------------------
 
-import QtQuick 2.0
+import QtQuick.Dialogs
 import "Main.js" as Logic
 
-PentobiFileDialog {
+FileDialog {
     title: qsTr("Open")
-    nameFilterLabels: [ qsTr("Blokus games") ]
-    nameFilters: [ [ "*.blksgf" ] ]
-    folder: rootWindow.folder
-    onOpened: name = ""
+    nameFilters: [ qsTr("Blokus games") + " (*.blksgf)" ]
+    currentFolder: rootWindow.folder
+    fileMode: FileDialog.OpenFile
     onAccepted: {
-        rootWindow.folder = folder
-        Logic.openFileUrl(openDialog.item.fileUrl)
+        rootWindow.folder = currentFolder
+        Logic.openFileUrl(selectedFile)
     }
 }

--- a/pentobi/qml/OpenDialogNative.qml
+++ b/pentobi/qml/OpenDialogNative.qml
@@ -1,6 +1,6 @@
 //-----------------------------------------------------------------------------
 /** @file pentobi/qml/OpenDialogNative.qml
-    @author Markus Enzenberger
+    @author Wing-chung Leung
     @copyright GNU General Public License version 3 or later */
 //-----------------------------------------------------------------------------
 

--- a/pentobi/qml/SaveDialogNative.qml
+++ b/pentobi/qml/SaveDialogNative.qml
@@ -1,0 +1,20 @@
+//-----------------------------------------------------------------------------
+/** @file pentobi/qml/SaveDialog.qml
+    @author Markus Enzenberger
+    @copyright GNU General Public License version 3 or later */
+//-----------------------------------------------------------------------------
+
+import QtQuick.Dialogs
+import "Main.js" as Logic
+
+FileDialog {
+    title: qsTr("Save")
+    defaultSuffix: "blksgf"
+    nameFilters: [ qsTr("Blokus games") + " (*.blksgf)" ]
+    currentFolder: rootWindow.folder
+    fileMode: FileDialog.SaveFile
+    onAccepted: {
+        rootWindow.folder = currentFolder
+        Logic.saveFile(Logic.getFileFromUrl(selectedFile), "")
+    }
+}

--- a/pentobi/qml/SaveDialogNative.qml
+++ b/pentobi/qml/SaveDialogNative.qml
@@ -1,6 +1,6 @@
 //-----------------------------------------------------------------------------
 /** @file pentobi/qml/SaveDialog.qml
-    @author Markus Enzenberger
+    @author Wing-chung Leung
     @copyright GNU General Public License version 3 or later */
 //-----------------------------------------------------------------------------
 

--- a/pentobi/resources_desktop.qrc
+++ b/pentobi/resources_desktop.qrc
@@ -2,14 +2,17 @@
 <qresource>
 <file>icons/pentobi/index.theme</file>
 <file>qml/AsciiArtSaveDialog.qml</file>
+<file>qml/AsciiArtSaveDialogNative.qml</file>
 <file>qml/GameViewDesktop.qml</file>
 <file>qml/HelpWindow.qml</file>
 <file>qml/ImageSaveDialog.qml</file>
+<file>qml/ImageSaveDialogNative.qml</file>
 <file>qml/NewFolderDialog.qml</file>
 <file>qml/OpenDialog.qml</file>
 <file>qml/OpenDialogNative.qml</file>
 <file>qml/PentobiFileDialog.qml</file>
 <file>qml/PieceSelectorDesktop.qml</file>
 <file>qml/SaveDialog.qml</file>
+<file>qml/SaveDialogNative.qml</file>
 </qresource>
 </RCC>

--- a/pentobi/resources_desktop.qrc
+++ b/pentobi/resources_desktop.qrc
@@ -7,6 +7,7 @@
 <file>qml/ImageSaveDialog.qml</file>
 <file>qml/NewFolderDialog.qml</file>
 <file>qml/OpenDialog.qml</file>
+<file>qml/OpenDialogNative.qml</file>
 <file>qml/PentobiFileDialog.qml</file>
 <file>qml/PieceSelectorDesktop.qml</file>
 <file>qml/SaveDialog.qml</file>


### PR DESCRIPTION
Switch to native file dialogs in Windows. The following dialogs are switched:
- Game open dialog
- Game save dialog
- Screenshot save dialog
- ASCII art save dialog

Suggesting filenames during file saves are not implemented because QtQuick.Dialogs.FileDialog does not support this.

Also, since the FileDialog QML in Qt 6.3 is incompatible with those in Qt 5.15, only Qt 6.2 or up is supported. (I have no information whether it works for Qt 6.0 or 6.1.)
